### PR TITLE
fix #40 handling of json flag on jql command

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -126,6 +126,13 @@ program
   .action(function(query, options) {
     if (options.custom_sql) {
       ls.aggregateResults(query, options, finalCb);
+    } else if(options.json) {
+      ls.jqlSearch(query, options, (err, issues) => {
+        if(issues) {
+          console.log(JSON.stringify(issues));
+        }
+        finalCb(err);
+      });
     } else {
       ls.jqlSearch(query, options, finalCb);
     }


### PR DESCRIPTION
As ls.getIssues short circuits when the json flag is passed in (it goes straight to the cb [finalCb in this case]) it results in nothing being outputted when this flag is used.

This commit handles the callback first and will output the issues in JSON if possible then navigate to the finalCb as before.