### PR TITLE
Enhancing mark to allow transitionId definition.

### DIFF
--- a/lib/jira/transitions.js
+++ b/lib/jira/transitions.js
@@ -86,7 +86,7 @@ module.exports = function () {
 
       sslRequest.post(config.auth.url + this.query).send(requestBody).end((err, res) => {
         if (!res.ok) {
-          return console.log((res.body.errorMessages || [res.error]).join('\n'));
+          cb((res.body.errorMessages || [res.error]).join('\n'));
         }
 
         if (cb) {
@@ -200,53 +200,58 @@ module.exports = function () {
         }
       });
     },
-    start: function (issue) {
+    start: function (issue, cb) {
       var that = this;
       this.transitionName = config.options['jira_start']['status'];
       this.getTransitionCode(issue, that.transitionName, function (transitionID) {
-        that.doTransition(issue, transitionID, function () {
-          return console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+        that.doTransition(issue, transitionID, function (err) {
+          console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+          cb(err);
         });
       });
     },
-    stop: function (issue) {
+    stop: function (issue, cb) {
       var that = this;
       this.transitionName = config.options['jira_stop']['status'];
       this.getTransitionCode(issue, that.transitionName, function (transitionID) {
-        that.doTransition(issue, transitionID, function () {
-          return console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+        that.doTransition(issue, transitionID, function (err) {
+          console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+          cb(err);
         });
       });
     },
-    review: function (issue) {
+    review: function (issue, cb) {
       var that = this;
       this.transitionName = config.options['jira_review']['status'];
       this.getTransitionCode(issue, that.transitionName, function (transitionID) {
-        that.doTransition(issue, transitionID, function () {
-          return console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+        that.doTransition(issue, transitionID, function (err) {
+          console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+          cb(err);
         });
       });
     },
-    done: function (issue, resolution) {
+    done: function (issue, resolution, cb) {
       var that = this;
       this.transitionName = config.options['jira_done']['status'];
       this.resolutionName = resolution;
       this.getResolutionCode(this.resolutionName, function (resolutionID) {
         that.getTransitionCode(issue, that.transitionName, function (transitionID) {
-          that.doTransition(issue, transitionID, resolutionID, function () {
-            return console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+          that.doTransition(issue, transitionID, resolutionID, function (err) {
+            console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+            cb(err);
           });
         });
       });
     },
-    invalid: function (issue, resolution) {
+    invalid: function (issue, resolution, cb) {
       var that = this;
       this.transitionName = config.options['jira_invalid']['status'];
       this.resolutionName = resolution;
       this.getResolutionCode(this.resolutionName, function (resolutionID) {
         that.getTransitionCode(issue, that.transitionName, function (transitionID) {
-          that.doTransition(issue, transitionID, resolutionID, function () {
-            return console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+          that.doTransition(issue, transitionID, resolutionID, function (err) {
+            console.log('Issue [' + issue + '] moved to ' + that.transitionName);
+            cb(err);
           });
         });
       });


### PR DESCRIPTION
In this change, i've enhanced the mark command to allow a transitionId to be passed in from the command line. This allows for greater scripting / automation possibilities.

We do not get the available transitions or ask the user to confirm their change for performance reasons but we assume a 502 error returned is a failed transition.

To enable this change I had to add error handling to transitions.doTransition which mean't changing the signature of the functions transitions. start, stop, review, done and invalid to accept a cb parameter and use accordingly inline with other areas of the cli.

@danshumaker 