### PR TITLE
Ensure base64encoding of Basic Auth token header

### DIFF
--- a/lib/ssl_request.js
+++ b/lib/ssl_request.js
@@ -3,16 +3,17 @@ module.exports = (() => {
   let request = require('superagent');
 
   var _buildRequest = function (verb) {
+    let base64AuthToken = Buffer.from(`${config.auth.user}:${config.auth.token}`).toString('base64');
     if (config.use_self_signed_certificate) {
       let ca = require('./ca');
       return argument => request[verb](argument)
         .ca(ca)
         .set('Content-Type', 'application/json')
-        .set('Authorization', 'Basic ' + config.auth.token);
+        .set('Authorization', 'Basic ' + base64AuthToken);
     } else {
       return argument => request[verb](argument)
         .set('Content-Type', 'application/json')
-        .set('Authorization', 'Basic ' + config.auth.token);
+        .set('Authorization', 'Basic ' + base64AuthToken);
     }
   };
 


### PR DESCRIPTION
When attempting to authenticate with the CLI using an Atlassian API Token, the following response is returned:

```
Basic authentication with passwords is deprecated.  For more information, see: https://confluence.atlassian.com/cloud/deprecation-of-basic-authentication-with-passwords-for-jira-and-confluence-apis-972355348.html
```

This PR adjusts the ssl_request.js file to ensure that the users email and password is included as a base64encoded authorization header instead of the token by itself.