### PR TITLE
Adding in the abiliity to unassign an issue.

### DIFF
--- a/bin/jira.js
+++ b/bin/jira.js
@@ -161,7 +161,10 @@ program
   });
 program
   .command('assign <issue> [accountId]')
-  .description('Assign an issue to <user>. Provide only issue# to assign to me')
+  .description(
+    'Assign an issue to <user>. Provide only issue# to assign to me.\n' +
+    'Use config (assign.unassignText) to choose what value to use to unassign an issue (default: \'null\').'
+  )
   .action(function(issue, user) {
     if (user) {
       user = config.user_alias[user] || user;

--- a/lib/config.js
+++ b/lib/config.js
@@ -53,6 +53,7 @@ module.exports = function () {
       options: configObject.options,
       custom_jql: configObject.custom_jql,
       custom_alasql: configObject.custom_alasql,
+      assign: configObject.assign,
       user_alias: configObject.user_alias,
       edit_meta: configObject.edit_meta,
       default_create: configObject.default_create,

--- a/lib/initial_config.js
+++ b/lib/initial_config.js
@@ -13,6 +13,9 @@ module.exports = function () {
       'priority': 'select fields->priority->name , count(1)  AS counter from ? group by fields->priority->name',
       'status': 'select fields->project->name,fields->status->name , count(1)  AS counter from ? group by fields->project->name,fields->status->name'
     },
+    'assign': {
+      'unassignText': 'null'
+    },
     'default_create': {
       '__always_ask': {
         'fields': {

--- a/lib/jira/assign.js
+++ b/lib/jira/assign.js
@@ -4,10 +4,16 @@ module.exports = function () {
   const utils = require('../utils');
   var config = require('../../lib/config');
 
+  const UNASSIGN_DEFAULT_TEXT = 'null';
+
   var assign = {
     query: null,
     table: null,
     to: function (ticket, assignee) {
+      const unassignText = config.assign && config.assign.unassignText ? config.assign.unassignText : UNASSIGN_DEFAULT_TEXT;
+      if(assignee === unassignText) {
+        assignee = null;
+      }
       this.query = 'rest/api/2/issue/' + ticket + '/assignee';
       sslRequest
         .put(config.auth.url + this.query)


### PR DESCRIPTION
A configurable value (default 'null') can be passed into the assign operation to unassign the issue.

I chose to make this configurable so users can decide on the best keyword for their use case.